### PR TITLE
Corrected typos

### DIFF
--- a/custom_components/mazda/manifest.json
+++ b/custom_components/mazda/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://github.com/fan00001/home-assistant-mazda/",
   "issue_tracker": "https://github.com/fano0001/home-assistant-mazda/issues",
   "iot_class": "cloud_polling",
-  "version": "1.2.0"
+  "version": "1.3.0"
 }

--- a/custom_components/mazda/pymazda/client.py
+++ b/custom_components/mazda/pymazda/client.py
@@ -206,7 +206,7 @@ class Client:  # noqa: D101
             "chargeInfo": {
                 "batteryLevelPercentage": charge_info.get("SmaphSOC"),
                 "drivingRangeKm": charge_info.get("SmaphRemDrvDistKm"),
-                "drivingRangeBevKm" charge_info.get("BatRemDrvDistKm"),
+                "drivingRangeBevKm": charge_info.get("BatRemDrvDistKm"),
                 "pluggedIn": charge_info.get("ChargerConnectorFitting") == 1,
                 "charging": charge_info.get("ChargeStatusSub") == 6,
                 "basicChargeTimeMinutes": charge_info.get("MaxChargeMinuteAC"),

--- a/custom_components/mazda/translations/en.json
+++ b/custom_components/mazda/translations/en.json
@@ -82,7 +82,7 @@
                 "name": "Charge level"
             },
             "ev_remaining_charging_time": {
-                "name" : "Remaining changing time (AC)"
+                "name" : "Remaining charging time (AC)"
             },
             "ev_remaining_range": {
                 "name": "Remaining range"


### PR DESCRIPTION
Corrected code typos.
Outstanding issue - install location (`/custom_components/mazda/` rather than installing to `/custom_components/mazda/mazda`).

I think I have identified why installs are going into sub directory, see https://github.com/hacs/integration/issues/931 - I think it is because th mazda domain has already been used. Maybe update manifest.json "domain": "mazda" to "domain": "mazda_vehicle" ? I did try removing integration, HACS integration repo link and fully restarting HA instance rather than just a reboot but that didnt work either