### PR TITLE
fix: Canadian Region support

### DIFF
--- a/custom_components/mazda_cs/oauth.py
+++ b/custom_components/mazda_cs/oauth.py
@@ -70,7 +70,7 @@ class MazdaOAuth2Implementation(LocalOAuth2ImplementationWithPkce):
         data = {
             "scope": " ".join(OAUTH2_AUTH[self._region]["scopes"]),
             "ui_locales": self.hass.config.language,
-            **({"email_domain_restrict": "mci", "international_phone_code_list": "mci", "country": "CA"} if self._region == "MCI" else {}),
+            **({"country": "CA", "email_domain_restrict": "mci", "international_phone_code_list": "mci"} if self._region == "MCI" else {}),
             "x-app-name": MSAL_APP_NAME,
             "x-app-ver": MSAL_APP_VER,
             "x-client-SKU": MSAL_CLIENT_SKU,


### PR DESCRIPTION
Pass extra headers unique to the MCI region. Confirmed working by users.