### PR TITLE
Migration pathway fix

### DIFF
--- a/custom_components/mazda_cs/config_flow.py
+++ b/custom_components/mazda_cs/config_flow.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import jwt
 import voluptuous as vol
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult, UNDEFINED
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
 from homeassistant.const import CONF_REGION
 from homeassistant.helpers import config_entry_oauth2_flow
 
@@ -139,7 +139,7 @@ class MazdaOAuth2FlowHandler(
                 self._abort_if_unique_id_mismatch(reason="wrong_account")
             return self.async_update_reload_and_abort(
                 reauth_entry,
-                unique_id=user_id if is_v1_migration else UNDEFINED,
+                unique_id=user_id,
                 data_updates=data,
             )
         self._abort_if_unique_id_configured()

--- a/custom_components/mazda_cs/config_flow.py
+++ b/custom_components/mazda_cs/config_flow.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import jwt
 import voluptuous as vol
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult, UNDEFINED
 from homeassistant.const import CONF_REGION
 from homeassistant.helpers import config_entry_oauth2_flow
 
@@ -133,9 +133,13 @@ class MazdaOAuth2FlowHandler(
         data[CONF_REGION] = self._region
 
         if self.source == SOURCE_REAUTH:
-            self._abort_if_unique_id_mismatch(reason="wrong_account")
+            reauth_entry = self._get_reauth_entry()
+            is_v1_migration = not reauth_entry.data.get("token")
+            if not is_v1_migration:
+                self._abort_if_unique_id_mismatch(reason="wrong_account")
             return self.async_update_reload_and_abort(
-                self._get_reauth_entry(),
+                reauth_entry,
+                unique_id=user_id if is_v1_migration else UNDEFINED,
                 data_updates=data,
             )
         self._abort_if_unique_id_configured()

--- a/custom_components/mazda_cs/pymazda/connection.py
+++ b/custom_components/mazda_cs/pymazda/connection.py
@@ -473,7 +473,7 @@ class Connection:
             raise MazdaException(
                 "The engine can only be remotely started 2 consecutive times. Please drive the vehicle to reset the counter."
             )
-        elif response_json.get("errorCode") == "400C01":
+        elif response_json.get("extraCode") == "400C01":
             raise MazdaTermsNotAcceptedException(
                 "Please accept the terms of service in the MyMazda app and try again"
             )


### PR DESCRIPTION
* Fixes migration path from v1 of the integration as users trickle in. Issue #55 
  * Skip wrong account check during v1 migration and store user_sub as unique_id, as expected 
* Potentially fixes terms of service exception - checks extraCode instead of errorCode (need debug)